### PR TITLE
Force `conan` to always use  `meson` 1.3.1

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -30,9 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
       - name: Cache conan artifacts
         id: conan-artifacts
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.x]
+
+ - Support rebuilding from source with Python 3.12 without `distutils`
+
 ## [1.1.0] 2024-04-17
 
  - New build system based on conan 2

--- a/native.profile
+++ b/native.profile
@@ -10,3 +10,5 @@ include(default)
 [tool_requires]
 meson/1.3.1
 
+[replace_tool_requires]
+meson/*: meson/1.3.1


### PR DESCRIPTION
Python 3.12 comes without `distutils` installed and requires using `meson` >= 1.2.3

Refs: https://github.com/conan-io/conan/issues/12929