### PR TITLE
Handle correctly C-style arrays in `numberArguments`/`arguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
  - macOS 14 `arm64` prebuilt binaries and support for rebuilding from source on macOS 14 `arm64`
  - The generation of the SWIG wrappers and the `npm` package is now reproducible and hosted in Github Actions, and the generated wrappers are included in the published package
  - Drop X11 support from the prebuilt binaries for headless installation, X11 support now requires rebuilding from source
- - Fix [], distortion methods require C-style arrays
+ - Fix [#220](https://github.com/mmomtchev/magickwand.js/issues/220), distortion methods require C-style arrays
 
 
 ## [1.1.0] 2024-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - macOS 14 `arm64` prebuilt binaries and support for rebuilding from source on macOS 14 `arm64`
  - The generation of the SWIG wrappers and the `npm` package is now reproducible and hosted in Github Actions, and the generated wrappers are included in the published package
  - Drop X11 support from the prebuilt binaries for headless installation, X11 support now requires rebuilding from source
+ - Fix [], distortion methods require C-style arrays
 
 
 ## [1.1.0] 2024-04-17

--- a/src/Image.i
+++ b/src/Image.i
@@ -82,7 +82,7 @@ emnapi_sync_memory(env, false, &ab_value, 0, NAPI_AUTO_LENGTH);
   $2_ltype &arg99 = $2;
   $typemap(in, double [], 1=arg99, 2=$1, argnum=99);
   // we know the size
-  $2 = $input.As<Napi::Array>().Length();
+  $1 = $input.As<Napi::Array>().Length();
 }
 %typemap(ts) (const size_t numberArguments_, const double *arguments_) "number[]";
 // Alternative spelling

--- a/src/Image.i
+++ b/src/Image.i
@@ -78,7 +78,7 @@ emnapi_sync_memory(env, false, &ab_value, 0, NAPI_AUTO_LENGTH);
   // arrays_javascript defines a typemap for double[], just inline it
   // we can't simply %apply because we want to extend it with
   // automatic size
-  // The 99 is needed because of a typemap deficiency in SWIG JSE 5.0.4
+  // The 99 is a workaround for https://github.com/mmomtchev/swig/issues/62
   $2_ltype &arg99 = $2;
   $typemap(in, double [], 1=arg99, 2=$1, argnum=99);
   // we know the size

--- a/src/Image.i
+++ b/src/Image.i
@@ -72,6 +72,24 @@ emnapi_sync_memory(env, false, &ab_value, 0, NAPI_AUTO_LENGTH);
 %}
 %typemap(tsout) Magick::TypeMetric *metrics "Magick.TypeMetric";
 
+%include <arrays_javascript.i>
+// Arguments in a C array
+%typemap(in) (const size_t numberArguments_, const double *arguments_) {
+  // arrays_javascript defines a typemap for double[], just inline it
+  // we can't simply %apply because we want to extend it with
+  // automatic size
+  // The 99 is needed because of a typemap deficiency in SWIG JSE 5.0.4
+  $2_ltype &arg99 = $2;
+  $typemap(in, double [], 1=arg99, 2=$1, argnum=99);
+  // we know the size
+  $2 = $input.As<Napi::Array>().Length();
+}
+%typemap(ts) (const size_t numberArguments_, const double *arguments_) "number[]";
+// Alternative spelling
+%apply (const size_t numberArguments_, const double *arguments_) {
+  (const size_t number_arguments_, const double *arguments_)
+};
+
 // These methods will be built without async version
 // (they are considered latency-free)
 // This is to reduce the RAM requirements when building

--- a/src/MagickCore.i
+++ b/src/MagickCore.i
@@ -7,6 +7,7 @@
 %rename("%s") MagickCore;
 %rename("%s", regextarget=1) ".+Operator$";
 %rename("%s", regextarget=1) ".+Op$";
+%rename("%s", regextarget=1) ".+Method$";
 %rename("%s", regextarget=1, %$not %$isfunction) ".+Options$";
 %rename("%s", regextarget=1, %$not %$isfunction) ".+Type$";
 %rename("%s", regextarget=1, %$isconstant) "Magick.+";

--- a/test/Image.shared.ts
+++ b/test/Image.shared.ts
@@ -8,7 +8,7 @@ export default function (
   bindingsMagickCore: typeof MagickCore
 ) {
   const { Image, Geometry, Color, Blob } = bindingsMagick;
-  const { MultiplyCompositeOp } = bindingsMagickCore;
+  const { MultiplyCompositeOp, AffineDistortion } = bindingsMagickCore;
 
   describe('Image', () => {
     describe('constructor', () => {
@@ -230,6 +230,15 @@ export default function (
 
       im = new Image();
       im.read(tmpBlob);
+      assert.equal(im.size().width(), 10);
+    });
+
+    it('distort', () => {
+      let im = new Image;
+
+      im.read(path);
+      assert.equal(im.size().width(), 80);
+      im.distort(AffineDistortion, [0.9, 1.0, 1.1, 0.9, 1.0, 1.1, 0.9, 1.0, 1.1], false);
       assert.equal(im.size().width(), 10);
     });
 

--- a/test/Image.shared.ts
+++ b/test/Image.shared.ts
@@ -144,7 +144,7 @@ export default function (
               }));
         });
 
-        it('write', function() {
+        it('write', function () {
           const im = new Image('15x20', new Color(0, 65535, 0, 0));
           const pixels = new typed(15 * 20 * 4);
 
@@ -162,7 +162,7 @@ export default function (
           }, /does not match the number of pixels/);
         });
 
-        it('writeAsync', function() {
+        it('writeAsync', function () {
           const im = new Image('15x20', new Color(0, 65535, 0, 0));
           const pixels = new typed(15 * 20 * 4);
 
@@ -238,8 +238,12 @@ export default function (
 
       im.read(path);
       assert.equal(im.size().width(), 80);
-      im.distort(AffineDistortion, [0.9, 1.0, 1.1, 0.9, 1.0, 1.1, 0.9, 1.0, 1.1], false);
-      assert.equal(im.size().width(), 10);
+      im.distort(AffineDistortion, [
+        3.5, 60.5, 3.5, 60.5,
+        32.5, 60.5, 32.5, 60.5,
+        3.5, 30.5, 33.5, 20.5
+      ], false);
+      assert.equal(im.size().width(), 80);
     });
 
     it('(async) read an image, crop it, write it and read it back', () => {


### PR DESCRIPTION
Fix #220 