### PR TITLE
update conan with clang 17 support

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,7 +32,8 @@ jobs:
           - windows-2019
           - windows-2022
           - macos-13
-          - macos-latest
+          - macos-14
+          - macos-15
         node-version: [18.x, 20.x, 22.x]
 
     steps:
@@ -85,7 +86,8 @@ jobs:
           - ubuntu-24.04
           - windows-2022
           - macos-13
-          - macos-latest
+          - macos-14
+          - macos-15
         node-version: [18.x, 20.x, 22.x]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Update the `hadron` build components
  - WASM built using the latest `emsdk` with a monolithic JS loader, requires the latest `vite` and features improved (simplified) compatibility with `rollup`
  - Update all delegate libraries to the latest `conan` versions
+ - Update `conan` to 2.16.1 allowing to rebuild using Apple clang 17 (macOS 15) with the default configuration
 
 ### [2.0.2] 2025-01-18
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -197,7 +197,7 @@ class ImageMagickDelegates(ConanFile):
       # libffi does not compile 
       # * on Windows with clang: https://github.com/conan-io/conan-center-index/issues/25241 
       # * on macOS 15 arm64: https://github.com/libffi/libffi/issues/852
-      self.glib_available = not self.clang_windows and not (self.settings.os == 'Macos' and self.settings.arch == 'armv8')
+      self.glib_available = not self.clang_windows and not (self.settings.os == 'Macos' and self.settings.arch == 'armv8' and int(self.settings.compiler.version.value) >= 17)
 
       # Fonts are not available on WASM targets
       self.fonts_enabled = self.options.fonts and self.settings.arch != 'wasm' and not self.clang_windows

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "devDependencies": {
       "@mmomtchev/python-xpack": "3.10.15-1",
       "@mmomtchev/meson-xpack": "1.8.0-1",
-      "@mmomtchev/conan-xpack": "2.15.0-1",
+      "@mmomtchev/conan-xpack": "2.16.1-1",
       "@xpack-dev-tools/cmake": "3.27.9-1.2",
       "@xpack-dev-tools/ninja-build": "1.11.1-3.1"
     },


### PR DESCRIPTION
and restore libffi for the macOS prebuilt binaries which use clang 16